### PR TITLE
Encode special characters in planet's name.

### DIFF
--- a/systems.html
+++ b/systems.html
@@ -134,7 +134,7 @@ $system 	= simplexml_load_file($filename);
 $planets	= $system->xpath('.//planet');
 foreach($planets as $planet){
 	print "<tr>\n";
-	print "\t<td><a href=\"./system.html?id=".$planet->name."\">".$planet->name."</a></td>\n";
+	print "\t<td><a href=\"./system.html?id=". urlencode($planet->name) . "\">".$planet->name."</a></td>\n";
 	print "\t<td>".$planet->mass."</td>\n";
 	print "\t<td>".$planet->semimajoraxis."</td>\n";
 	print "</tr>\n";
@@ -183,7 +183,7 @@ function getValueForPlanetAndKey(planet,key){
 
 		case "name:first":
  			var name = $(key,planet).text();
-			return "<a href='./system.html?id="+name+"'>"+name+"</a>";
+			return "<a href='./system.html?id="+encodeURIComponent(name)+"'>"+name+"</a>";
 		default:
  			return getFormatForTag($(key,planet));
 	}


### PR DESCRIPTION
Hi,

I was browsing randomly the catalogue website.
When you click on a planet which has a '+' in its name on the systems.html page, for instance on "2M 0746+20 b", it would display "System not found: 2M 0746 20 b".
See the table in: http://www.openexoplanetcatalogue.com/systems.html

You must encode the URL to ensure any special character is correctly url-encoded.
This commit makes the change and fix the broken links.
