### PR TITLE
Update habitable zone calculation

### DIFF
--- a/oec_filters.py
+++ b/oec_filters.py
@@ -16,58 +16,21 @@ def isHabitable(xmlPair):
     maxa = 0
     if star is None:
         return False # no binary systems (yet)
-    semimajoraxis = getFloat(planet,"./semimajoraxis")
-    if semimajoraxis is None:
-        hostmass = getFloat(star,"./mass",1.)
-        period = getFloat(planet,"./period",265.25)
-        semimajoraxis = pow(pow(period/6.283/365.25,2)*39.49/hostmass,1.0/3.0) 
 
+    semimajoraxis = getFloat(planet,"./semimajoraxis")
     temperature = getFloat(star,"./temperature")
-    spectralTypeMain = getText(star,"./spectraltype","G")[0]
-    if temperature is None:
-        if spectralTypeMain=="O":
-            temperature = 40000
-        if spectralTypeMain=="B":
-            temperature = 20000
-        if spectralTypeMain=="A":
-            temperature = 8500
-        if spectralTypeMain=="F":
-            temperature = 6500
-        if spectralTypeMain=="G":
-            temperature = 5500
-        if spectralTypeMain=="K":
-            temperature = 4000
-        if spectralTypeMain=="M":
-            temperature = 3000
+    stellarMass = getFloat(star,"./mass")
+    stellarRadius = getFloat(star,"./radius")
+    period = getFloat(planet,"./period")
+    
+    if semimajoraxis is None and stellarMass is not None and period is not None:
+        semimajoraxis = pow(pow(period/6.283/365.25,2)*39.49/stellarMass,1.0/3.0) 
+
+    if semimajoraxis is None or temperature is None or stellarRadius is None:
+        return False # insufficient information to determine habitability
         
     rel_temp = temperature - 5700.
-    
-    stellarMass = getFloat(star,"./mass")
-    if stellarMass is None:
-        stellarMass = 1.
-    
-    stellarRadius = getFloat(star,"./radius")
-    if stellarRadius is None or stellarRadius<0.01:
-        stellarRadius = 1.
-        if spectralTypeMain=='O': 
-            stellarRadius=10.
-        if spectralTypeMain=='B': 
-            stellarRadius=3.0
-        if spectralTypeMain=='A': 
-            stellarRadius=1.5
-        if spectralTypeMain=='F': 
-            stellarRadius=1.3
-        if spectralTypeMain=='G': 
-            stellarRadius=1.0
-        if spectralTypeMain=='K': 
-            stellarRadius=0.8
-        if spectralTypeMain=='M': 
-            stellarRadius=0.5
-    
-    if stellarMass>2.:
-        luminosity = pow(stellarMass,3.5)
-    else:
-        luminosity = pow(stellarMass,4.)
+    luminosity = pow(stellarRadius, 2.) * pow(temperature / 5780., 4.)
     
     # Ref: http://adsabs.harvard.edu/abs/2007A%26A...476.1373S
     HZinner2 = (0.68-2.7619e-5*rel_temp-3.8095e-9*rel_temp*rel_temp) *sqrt(luminosity);

--- a/visualizations.py
+++ b/visualizations.py
@@ -134,60 +134,20 @@ def habitable(xmlPair):
         if semimajoraxis>maxa:
             maxa = semimajoraxis
 
-    temperature = getFloat(star,"./temperature")
-    spectralTypeMain = getText(star,"./spectraltype","G")[0]
-    if temperature is None:
-        if spectralTypeMain=="O":
-            temperature = 40000
-        if spectralTypeMain=="B":
-            temperature = 20000
-        if spectralTypeMain=="A":
-            temperature = 8500
-        if spectralTypeMain=="F":
-            temperature = 6500
-        if spectralTypeMain=="G":
-            temperature = 5500
-        if spectralTypeMain=="K":
-            temperature = 4000
-        if spectralTypeMain=="M":
-            temperature = 3000
-        
-    rel_temp = temperature - 5700.
-    
-    stellarMass = getFloat(star,"./mass")
-    if stellarMass is None:
-        stellarMass = 1.
-    
     stellarRadius = getFloat(star,"./radius")
-    if stellarRadius is None or stellarRadius<0.01:
-        stellarRadius = 1.
-        if spectralTypeMain=='O': 
-            stellarRadius=10.
-        if spectralTypeMain=='B': 
-            stellarRadius=3.0
-        if spectralTypeMain=='A': 
-            stellarRadius=1.5
-        if spectralTypeMain=='F': 
-            stellarRadius=1.3
-        if spectralTypeMain=='G': 
-            stellarRadius=1.0
-        if spectralTypeMain=='K': 
-            stellarRadius=0.8
-        if spectralTypeMain=='M': 
-            stellarRadius=0.5
+    temperature = getFloat(star,"./temperature")
     
-    if stellarMass>2.:
-        luminosity = pow(stellarMass,3.5)
-    else:
-        luminosity = pow(stellarMass,4.)
+    if stellarRadius is None or temperature is None:
+        return None # insufficient information to determine habitable zone
+
+    rel_temp = temperature - 5700.
+    luminosity = pow(stellarRadius, 2.) * pow(temperature / 5780., 4.)
     
     # Ref: http://adsabs.harvard.edu/abs/2007A%26A...476.1373S
     HZinner2 = (0.68-2.7619e-5*rel_temp-3.8095e-9*rel_temp*rel_temp) *sqrt(luminosity);
     HZouter2 = (1.95-1.3786e-4*rel_temp-1.4286e-9*rel_temp*rel_temp) *sqrt(luminosity);
     HZinner = (0.95-2.7619e-5*rel_temp-3.8095e-9*rel_temp*rel_temp) *sqrt(luminosity);
     HZouter = (1.67-1.3786e-4*rel_temp-1.4286e-9*rel_temp*rel_temp) *sqrt(luminosity);
-
-
 
     width = 600
     height= 100


### PR DESCRIPTION
Noticed a number of highly suspicious habitable zone determinations on the website, so took a look and found that the luminosity is being computed based on an assumed main sequence mass-luminosity relationship, and in case information is missing the star is assumed to be a solar analogue, which is often not the case.

This changes the calculation to use stellar radius and temperature. If temperature/radius information is missing, the habitable zone is not computed.