### PR TITLE
Update to stellar luminosity calculations for habitable zones

### DIFF
--- a/habitablezone.py
+++ b/habitablezone.py
@@ -1,59 +1,51 @@
 from numberformat import getFloat, getText
 from math import *
 
+spectralTypeTempRadius = {
+    "O": (40000., 10.),
+    "B": (20000., 3.0),
+    "A": (8500., 1.5),
+    "F": (6500., 1.3),
+    "G": (5500., 1.0),
+    "K": (4000., 0.8),
+    "M": (3000., 0.5)
+}
+
 def hzLimits(xmlPair):
     system, planet, star, filename = xmlPair
     if star is None:
         return None
 
     temperature = getFloat(star,"./temperature")
-    spectralTypeMain = getText(star,"./spectraltype","G")[0]
-    if temperature is None:
-        if spectralTypeMain=="O":
-            temperature = 40000
-        if spectralTypeMain=="B":
-            temperature = 20000
-        if spectralTypeMain=="A":
-            temperature = 8500
-        if spectralTypeMain=="F":
-            temperature = 6500
-        if spectralTypeMain=="G":
-            temperature = 5500
-        if spectralTypeMain=="K":
-            temperature = 4000
-        if spectralTypeMain=="M":
-            temperature = 3000
-        else:
+    stellarRadius = getFloat(star,"./radius")
+    if temperature is not None and stellarRadius is not None:
+        if stellarRadius < 0.01:
+            # no habitable zone for pulsars
             return None
+        luminosity = (temperature/5778.)**4 * stellarRadius**2
+    else:
+        stellarMass = getFloat(star,"./mass")
+        if stellarMass is None:
+            return None
+        elif stellarMass>2.:
+            luminosity = pow(stellarMass,3.5)
+        else:
+            luminosity = pow(stellarMass,4.)
+
+    spectralTypeMain = getText(star,"./spectraltype","")[:1]
+    try:
+        spTemperature, spRadius = spectralTypeTempRadius[spectralTypeMain]
+        if temperature is None:
+            temperature = spTemperature
+        if stellarRadius is None:
+            stellarRadius = spRadius
+    except KeyError:
+        if temperature is None:
+            temperature = 5700.
+        if stellarRadius is None:
+            stellarRadius = 1.
 
     rel_temp = temperature - 5700.
-
-    stellarMass = getFloat(star,"./mass")
-    if stellarMass is None:
-        stellarMass = 1.
-
-    stellarRadius = getFloat(star,"./radius")
-    if stellarRadius is None or stellarRadius<0.01:
-        stellarRadius = 1.
-        if spectralTypeMain=='O':
-            stellarRadius=10.
-        if spectralTypeMain=='B':
-            stellarRadius=3.0
-        if spectralTypeMain=='A':
-            stellarRadius=1.5
-        if spectralTypeMain=='F':
-            stellarRadius=1.3
-        if spectralTypeMain=='G':
-            stellarRadius=1.0
-        if spectralTypeMain=='K':
-            stellarRadius=0.8
-        if spectralTypeMain=='M':
-            stellarRadius=0.5
-
-    if stellarMass>2.:
-        luminosity = pow(stellarMass,3.5)
-    else:
-        luminosity = pow(stellarMass,4.)
 
     # Ref: http://adsabs.harvard.edu/abs/2007A%26A...476.1373S
     HZinner2 = (0.68-2.7619e-5*rel_temp-3.8095e-9*rel_temp*rel_temp) *sqrt(luminosity);

--- a/habitablezone.py
+++ b/habitablezone.py
@@ -1,0 +1,64 @@
+from numberformat import getFloat, getText
+from math import *
+
+def hzLimits(xmlPair):
+    system, planet, star, filename = xmlPair
+    if star is None:
+        return None
+
+    temperature = getFloat(star,"./temperature")
+    spectralTypeMain = getText(star,"./spectraltype","G")[0]
+    if temperature is None:
+        if spectralTypeMain=="O":
+            temperature = 40000
+        if spectralTypeMain=="B":
+            temperature = 20000
+        if spectralTypeMain=="A":
+            temperature = 8500
+        if spectralTypeMain=="F":
+            temperature = 6500
+        if spectralTypeMain=="G":
+            temperature = 5500
+        if spectralTypeMain=="K":
+            temperature = 4000
+        if spectralTypeMain=="M":
+            temperature = 3000
+        else:
+            return None
+
+    rel_temp = temperature - 5700.
+
+    stellarMass = getFloat(star,"./mass")
+    if stellarMass is None:
+        stellarMass = 1.
+
+    stellarRadius = getFloat(star,"./radius")
+    if stellarRadius is None or stellarRadius<0.01:
+        stellarRadius = 1.
+        if spectralTypeMain=='O':
+            stellarRadius=10.
+        if spectralTypeMain=='B':
+            stellarRadius=3.0
+        if spectralTypeMain=='A':
+            stellarRadius=1.5
+        if spectralTypeMain=='F':
+            stellarRadius=1.3
+        if spectralTypeMain=='G':
+            stellarRadius=1.0
+        if spectralTypeMain=='K':
+            stellarRadius=0.8
+        if spectralTypeMain=='M':
+            stellarRadius=0.5
+
+    if stellarMass>2.:
+        luminosity = pow(stellarMass,3.5)
+    else:
+        luminosity = pow(stellarMass,4.)
+
+    # Ref: http://adsabs.harvard.edu/abs/2007A%26A...476.1373S
+    HZinner2 = (0.68-2.7619e-5*rel_temp-3.8095e-9*rel_temp*rel_temp) *sqrt(luminosity);
+    HZinner = (0.95-2.7619e-5*rel_temp-3.8095e-9*rel_temp*rel_temp) *sqrt(luminosity);
+    HZouter = (1.67-1.3786e-4*rel_temp-1.4286e-9*rel_temp*rel_temp) *sqrt(luminosity);
+    HZouter2 = (1.95-1.3786e-4*rel_temp-1.4286e-9*rel_temp*rel_temp) *sqrt(luminosity);
+
+    return HZinner2, HZinner, HZouter, HZouter2, stellarRadius

--- a/oec_filters.py
+++ b/oec_filters.py
@@ -1,4 +1,5 @@
 from numberformat import getFloat, getText
+from habitablezone import hzLimits
 from math import *
 
 titles = {
@@ -11,48 +12,23 @@ titles = {
     "discoveryrv":                  "Planets discovered by RV",
 }
 
-spectraltypes_temp_radii = {'O' : (40000,10.) , 'B': (20000,3.0), 'A' : (8500, 1.5), 'F' : (6500, 1.3), 'G' : (5500, 1.0), 'K': (4000, 0.8) , 'M' : (3000, 0.5) }
-
 def isHabitable(xmlPair):
     system, planet, star, filename = xmlPair
     maxa = 0
     if star is None:
         return False # no binary systems (yet)
-    spectralTypeMain = getText(star,"./spectraltype","G")[0]
-    if spectralTypeMain not in spectraltypes_temp_radii :
-        return False # unsupported spectral type 
+
+    hzData = hzLimits(xmlPair)
+    if hzData is None:
+        return False
+
+    HZinner2, HZinner, HZouter, HZouter2, stellarRadius = hzData
+
     semimajoraxis = getFloat(planet,"./semimajoraxis")
     if semimajoraxis is None:
         hostmass = getFloat(star,"./mass",1.)
         period = getFloat(planet,"./period",265.25)
         semimajoraxis = pow(pow(period/6.283/365.25,2)*39.49/hostmass,1.0/3.0)
-
-    temperature = getFloat(star,"./temperature")
-
-    if temperature is None:
-        temperature = spectraltypes_temp_radii[spectralTypeMain][0]
-
-    rel_temp = temperature - 5700.
-
-    stellarMass = getFloat(star,"./mass")
-    if stellarMass is None:
-        stellarMass = 1.
-
-    stellarRadius = getFloat(star,"./radius")
-    if stellarRadius is None or stellarRadius<0.01:
-        stellarRadius = 1.
-        if spectralTypeMain in spectraltypes_temp_radii:
-            stellarRadius = spectraltypes_temp_radii[spectralTypeMain][1]
-
-
-    if stellarMass>2.:
-        luminosity = pow(stellarMass,3.5)
-    else:
-        luminosity = pow(stellarMass,4.)
-
-    # Ref: http://adsabs.harvard.edu/abs/2007A%26A...476.1373S
-    HZinner2 = (0.68-2.7619e-5*rel_temp-3.8095e-9*rel_temp*rel_temp) *sqrt(luminosity);
-    HZouter2 = (1.95-1.3786e-4*rel_temp-1.4286e-9*rel_temp*rel_temp) *sqrt(luminosity);
 
     if semimajoraxis>HZinner2 and semimajoraxis<HZouter2:
         return True

--- a/visualizations.py
+++ b/visualizations.py
@@ -1,5 +1,6 @@
 from math import *
 from numberformat import getFloat, getText, renderFloat
+from habitablezone import hzLimits
 
 width = 480
 height= 200
@@ -42,7 +43,7 @@ def plotplanet(radius,name,ss,todooooooo=1):
             style = "fill:url(#g1); stroke:none"
     svg += '<circle cx="%f" cy="%f" r="%f" style="%s" />' %(
                 pl_i+earth*radius+1,
-                y, 
+                y,
                 earth*radius,
                 style)
     svg += '<line x1="%f" y1="%f" x2="%f" y2="%f" fill="none" stroke="lightgrey" />'%(
@@ -60,7 +61,7 @@ def plotplanet(radius,name,ss,todooooooo=1):
 
 def size(xmlPair):
     global earth,pl_i,texty
-    system, planet, star, filename = xmlPair 
+    system, planet, star, filename = xmlPair
     planets = system.findall(".//planet")
     maxr = max(map(getRadius,planets))
     pl_i=0
@@ -111,16 +112,22 @@ def size(xmlPair):
         radius = getRadius(p)
         if radius is not None:
             svg += plotplanet(radius, p.find("./name").text, False)
-    
+
     svg += " </g>"
     return svg
 
 
 def habitable(xmlPair):
-    system, planet, star, filename = xmlPair 
+    system, planet, star, filename = xmlPair
 
     if star is None:
         return None # cannot draw diagram for binary systems yet
+
+    hzdata = hzLimits(xmlPair)
+    if hzdata is None:
+        return None
+
+    HZinner2, HZinner, HZouter, HZouter2, stellarRadius = hzdata
 
     planets = system.findall(".//planet")
 
@@ -130,64 +137,9 @@ def habitable(xmlPair):
         if semimajoraxis is None:
             hostmass = getFloat(star,"./mass",1.)
             period = getFloat(planet,"./period",265.25)
-            semimajoraxis = pow(pow(period/6.283/365.25,2)*39.49/hostmass,1.0/3.0) 
+            semimajoraxis = pow(pow(period/6.283/365.25,2)*39.49/hostmass,1.0/3.0)
         if semimajoraxis>maxa:
             maxa = semimajoraxis
-
-    temperature = getFloat(star,"./temperature")
-    spectralTypeMain = getText(star,"./spectraltype","G")[0]
-    if temperature is None:
-        if spectralTypeMain=="O":
-            temperature = 40000
-        if spectralTypeMain=="B":
-            temperature = 20000
-        if spectralTypeMain=="A":
-            temperature = 8500
-        if spectralTypeMain=="F":
-            temperature = 6500
-        if spectralTypeMain=="G":
-            temperature = 5500
-        if spectralTypeMain=="K":
-            temperature = 4000
-        if spectralTypeMain=="M":
-            temperature = 3000
-        
-    rel_temp = temperature - 5700.
-    
-    stellarMass = getFloat(star,"./mass")
-    if stellarMass is None:
-        stellarMass = 1.
-    
-    stellarRadius = getFloat(star,"./radius")
-    if stellarRadius is None or stellarRadius<0.01:
-        stellarRadius = 1.
-        if spectralTypeMain=='O': 
-            stellarRadius=10.
-        if spectralTypeMain=='B': 
-            stellarRadius=3.0
-        if spectralTypeMain=='A': 
-            stellarRadius=1.5
-        if spectralTypeMain=='F': 
-            stellarRadius=1.3
-        if spectralTypeMain=='G': 
-            stellarRadius=1.0
-        if spectralTypeMain=='K': 
-            stellarRadius=0.8
-        if spectralTypeMain=='M': 
-            stellarRadius=0.5
-    
-    if stellarMass>2.:
-        luminosity = pow(stellarMass,3.5)
-    else:
-        luminosity = pow(stellarMass,4.)
-    
-    # Ref: http://adsabs.harvard.edu/abs/2007A%26A...476.1373S
-    HZinner2 = (0.68-2.7619e-5*rel_temp-3.8095e-9*rel_temp*rel_temp) *sqrt(luminosity);
-    HZouter2 = (1.95-1.3786e-4*rel_temp-1.4286e-9*rel_temp*rel_temp) *sqrt(luminosity);
-    HZinner = (0.95-2.7619e-5*rel_temp-3.8095e-9*rel_temp*rel_temp) *sqrt(luminosity);
-    HZouter = (1.67-1.3786e-4*rel_temp-1.4286e-9*rel_temp*rel_temp) *sqrt(luminosity);
-
-
 
     width = 600
     height= 100
@@ -196,13 +148,13 @@ def habitable(xmlPair):
 
     svg = """
         <defs>
-            <radialGradient id="habitablegradient" > 
+            <radialGradient id="habitablegradient" >
                 <stop id="stops0" offset=".0" stop-color="lightgreen" stop-opacity="0"/>
                 <stop id="stops1" offset="%f" stop-color="lightgreen" stop-opacity="0"/>
                 <stop id="stops2" offset="%f" stop-color="lightgreen" stop-opacity="1"/>
                 <stop id="stops3" offset="%f" stop-color="lightgreen" stop-opacity="1"/>
                 <stop id="stops4" offset="1" stop-color="lightgreen" stop-opacity="0"/>
-            </radialGradient> 
+            </radialGradient>
         </defs>
         """ %(HZinner2/HZouter2, HZinner/HZouter2,HZouter/HZouter2 )
     if HZinner2<maxa*2:
@@ -215,20 +167,20 @@ def habitable(xmlPair):
                 au*HZinner2,
                 height-1)
 
-        
+
     svg += '<ellipse cx="%f" cy="%f" rx="%f" ry="%f" style="fill:red" />' %(
                 0.,
                 height/2,
                 au*stellarRadius*0.0046524726,
                 au*stellarRadius*0.0046524726)
-    
+
     svg += '<g style="stroke:black;">'
     for planet in planets:
         semimajoraxis = getFloat(planet,"./semimajoraxis")
         if semimajoraxis is None:
             hostmass = getFloat(star,"./mass",1.)
             period = getFloat(planet,"./period",265.25)
-            semimajoraxis = pow(pow(period/6.283/365.25,2)*39.49/hostmass,1.0/3.0) 
+            semimajoraxis = pow(pow(period/6.283/365.25,2)*39.49/hostmass,1.0/3.0)
         size= 12
         textx=semimajoraxis*au+2
         texty=last_text_y+size
@@ -246,7 +198,7 @@ def habitable(xmlPair):
                     size,
                     getText(planet,"./name"))
         svg += '</g>'
-    
+
     return svg
 
 def textArchitecture(o,stype=0):
@@ -269,11 +221,11 @@ def textArchitecture(o,stype=0):
             else:
                  architecture += ", "+renderFloat(period)+" days"
         architecture += textArchitecture(b,2)
-   
+
     ss = o.findall("./star")
     for s in ss:
         architecture += "<li><img src=\"/static/img/star.png\" width=\"16\" height=\"16\" />&nbsp;"+s.find("./name").text+", stellar object"
-        architecture += textArchitecture(s)         
+        architecture += textArchitecture(s)
 
     ps = o.findall("./planet")
     for p in ps:


### PR DESCRIPTION
This patch updates the habitable zone calculation to use the stellar radius and temperature to estimate the stellar luminosity in preference to the existing calculation based on the mass-radius relationship for main-sequence stars. This should fix various planets around giant stars from getting listed as habitable because of the severe underestimation of the stellar luminosity, provided the system has sufficient information listed.

I have also extracted the habitable zone calculation from the filters and the visualisation code into a single place.