### PR TITLE
Update habitable zone visualization for systems with multiple planet host stars

### DIFF
--- a/habitablezone.py
+++ b/habitablezone.py
@@ -11,17 +11,16 @@ spectralTypeTempRadius = {
     "M": (3000., 0.5)
 }
 
-def hzLimits(xmlPair):
-    system, planet, star, filename = xmlPair
+def hzLimits(star):
     if star is None:
         return None
 
     temperature = getFloat(star,"./temperature")
     stellarRadius = getFloat(star,"./radius")
+    if stellarRadius is not None and stellarRadius < 0.01:
+        return None
+
     if temperature is not None and stellarRadius is not None:
-        if stellarRadius < 0.01:
-            # no habitable zone for pulsars
-            return None
         luminosity = (temperature/5778.)**4 * stellarRadius**2
     else:
         stellarMass = getFloat(star,"./mass")

--- a/oec_filters.py
+++ b/oec_filters.py
@@ -18,7 +18,7 @@ def isHabitable(xmlPair):
     if star is None:
         return False # no binary systems (yet)
 
-    hzData = hzLimits(xmlPair)
+    hzData = hzLimits(star)
     if hzData is None:
         return False
 

--- a/templates/planet.html
+++ b/templates/planet.html
@@ -153,17 +153,22 @@ Note that unless the radius has been determined through a transit observation, t
 </svg>
 
 
-{% if vizhabitable %}
+{% if vizhabitable|length > 0 %}
 <h3>Habitable zone</h3>
 <p>
 The following plot shows the approximate location of the planets in this system with respect to the habitable zone (green) and the size of the star (red).
-This is only an estimate, using the star's spectral type and mass. 
+This is only an estimate, using the star's spectral type and mass.
 Note that if no green band is shown in the plot, then the planet's orbit is far outside the habitable zone.
-The equations of <a href="http://adsabs.harvard.edu/abs/2007A%26A...476.1373S">Selsis, Kasting et al</a> are used to draw the inner and outer boundaries. 
+The equations of <a href="http://adsabs.harvard.edu/abs/2007A%26A...476.1373S">Selsis, Kasting et al</a> are used to draw the inner and outer boundaries.
 </p>
+{% for visualization in vizhabitable %}
+{% if vizhabitable|length > 1 %}
+<h4>{{visualization[0]}}</h4>
+{% endif %}
 <svg width="600" height="100">
-{{ vizhabitable|safe }}
+{{ visualization[1]|safe }}
 </svg>
+{% endfor %}
 {% endif  %}
 
 


### PR DESCRIPTION
Render each host star in systems with multiple host stars with their own separate diagram. This fixes the situation where all planets get rendered against the same habitable zone.

Examples Proxima Centauri, XO-2